### PR TITLE
Only run autosize only if v-autosize attribute is truthy.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ var autoSizeInput = require('autosize-input')
 exports.install = function(Vue) {
   Vue.directive('autosize', {
     bind: function(el, binding) {
+      if (!binding.value) return 
       var tagName = el.tagName
       if (tagName == 'TEXTAREA') {
         autosize(el)
@@ -13,6 +14,7 @@ exports.install = function(Vue) {
     },
 
     componentUpdated: function(el, binding, vnode) {
+      if (!binding.value) return 
       var tagName = el.tagName
       if (tagName == 'TEXTAREA') {
         autosize.update(el)
@@ -21,7 +23,8 @@ exports.install = function(Vue) {
       }
     },
 
-    unbind: function(el) {
+    unbind: function(el, binding) {
+      if (!binding.value) return 
       autosize.destroy(el)
     }
   })


### PR DESCRIPTION
I use this plugin inside a wrapper component, and I have a boolean prop that specifies whether autosize should be enabled/disabled. 

I pass this prop through on the v-autosize attribute, however, if the value is false, the autosize functionality is still enabled as currently it only checks for the existence of the attribute not if it is 'truthy'

This commit changes this, so ```v-autosize="false"``` works as expected.